### PR TITLE
Adapt Xero integration to OAuth2 changes

### DIFF
--- a/catalog/destinations/xero/lib/types.ts
+++ b/catalog/destinations/xero/lib/types.ts
@@ -1,7 +1,5 @@
 export interface XeroOAuth2TokenSet {
   access_token: string;
-  expires_at: number;
   token_type: string;
   refresh_token: string;
-  scope: string;
 }

--- a/catalog/destinations/xero/test/index.test.ts
+++ b/catalog/destinations/xero/test/index.test.ts
@@ -6,24 +6,14 @@ jest.mock("axios");
 describe("Test: Xero Destination", () => {
   let driver: XeroDriver | null = null;
 
-  const oauth2 = {
-    redirectUri: "http://localhost:3000/callback",
-    scopes: ["openid", "profile", "email", "accounting.transactions"],
-    resolved: {
-      access_token: "access_token",
-      expires_at: 1999999999,
-      expires_in: 1999999999,
-      id_token: "id_token",
-      refresh_token: "refresh_token",
-    },
-  };
-
   // mock implementation of driver.client
 
   it("should reject unknown methods from the proxy object", async () => {
     driver = getProxyDriver({
       XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
       XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
+      XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+      XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
     });
 
     try {
@@ -38,7 +28,8 @@ describe("Test: Xero Destination", () => {
       driver = getProxyDriver({
         XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
         XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-        oauth2,
+        XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+        XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
       });
 
       const mockedResponse = { data: [{ tenantId: "tenant1" }, { tenantId: "tenant2" }, { tenantId: "tenant3" }] };
@@ -61,13 +52,13 @@ describe("Test: Xero Destination", () => {
       driver = getProxyDriver({
         XERO_CLIENT_ID: "",
         XERO_CLIENT_SECRET: "",
-        oauth2: {},
       });
 
       await driver.connect({
         XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
         XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-        oauth2,
+        XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+        XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
       });
 
       expect(driver.client).toBeDefined();
@@ -89,7 +80,8 @@ describe("Test: Xero Destination", () => {
         await driver.connect({
           XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
           XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-          oauth2,
+          XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+          XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
         });
 
         fail("Should have thrown an error");
@@ -104,7 +96,8 @@ describe("Test: Xero Destination", () => {
       driver = getProxyDriver({
         XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
         XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-        oauth2,
+        XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+        XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
       });
     });
 
@@ -131,7 +124,8 @@ describe("Test: Xero Destination", () => {
       driver = getProxyDriver({
         XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
         XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-        oauth2,
+        XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+        XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
       });
 
       const mockedResponse = { data: [{ tenantId: "tenant1" }, { tenantId: "tenant2" }, { tenantId: "tenant3" }] };
@@ -169,7 +163,8 @@ describe("Test: Xero Destination", () => {
       driver = getProxyDriver({
         XERO_CLIENT_ID: process.env.XERO_CLIENT_ID,
         XERO_CLIENT_SECRET: process.env.XERO_CLIENT_SECRET,
-        oauth2,
+        XERO_ACCESS_TOKEN: process.env.XERO_ACCESS_TOKEN,
+        XERO_REFRESH_TOKEN: process.env.XERO_REFRESH_TOKEN,
       });
 
       const mockedResponse = { data: [{ tenantId: "tenant1" }, { tenantId: "tenant2" }, { tenantId: "tenant3" }] };

--- a/catalog/destinations/xero/xero.ts
+++ b/catalog/destinations/xero/xero.ts
@@ -8,27 +8,36 @@ export class XeroDriver implements DestinationClassI {
 
   public tenantIds: string[];
 
-  private readonly XERO_CLIENT_ID: any;
+  private readonly XERO_CLIENT_ID: string;
 
-  private readonly XERO_CLIENT_SECRET: any;
+  private readonly XERO_CLIENT_SECRET: string;
 
-  constructor({ XERO_CLIENT_ID, XERO_CLIENT_SECRET }: AnyObject) {
+  private readonly XERO_ACCESS_TOKEN: string;
+
+  private readonly XERO_REFRESH_TOKEN: string;
+
+  constructor({ XERO_CLIENT_ID, XERO_CLIENT_SECRET, XERO_ACCESS_TOKEN, XERO_REFRESH_TOKEN }: AnyObject) {
     this.XERO_CLIENT_ID = XERO_CLIENT_ID;
     this.XERO_CLIENT_SECRET = XERO_CLIENT_SECRET;
+    this.XERO_ACCESS_TOKEN = XERO_ACCESS_TOKEN;
+    this.XERO_REFRESH_TOKEN = XERO_REFRESH_TOKEN;
   }
 
   async connect(config?: AnyObject): Promise<void | Truthy> {
     // initialize Xero client
     this.client = new XeroClient({
-      clientId: config.XERO_CLIENT_ID || this.XERO_CLIENT_ID,
-      clientSecret: config.XERO_CLIENT_SECRET || this.XERO_CLIENT_SECRET,
-      redirectUris: [config.oauth2.redirectUri],
-      scopes: config.oauth2.scopes,
+      clientId: config?.XERO_CLIENT_ID || this.XERO_CLIENT_ID,
+      clientSecret: config?.XERO_CLIENT_SECRET || this.XERO_CLIENT_SECRET,
       httpTimeout: 3000,
     });
 
     // set up Xero OAuth2 token set
-    const tokenSet: XeroOAuth2TokenSet = config.oauth2.resolved;
+    const tokenSet: XeroOAuth2TokenSet = {
+      access_token: config?.XERO_ACCESS_TOKEN || this.XERO_ACCESS_TOKEN,
+      refresh_token: config?.XERO_REFRESH_TOKEN || this.XERO_REFRESH_TOKEN,
+      token_type: "Bearer",
+    };
+
     this.client.setTokenSet(tokenSet as TokenSet);
 
     // get and save all registered tenants
@@ -91,6 +100,8 @@ export class XeroDriver implements DestinationClassI {
           .match(/\((.*?)\)/)?.[1] || "")
           .split(",")
           .map((param) => param.trim()) as Parameters<typeof targetMethod>;
+
+        console.log("methodParams ===> ", methodParams);
         break;
 
       default:


### PR DESCRIPTION
This pull request adapts Xero destination integration to the new OAuth2 implementation on Event. The class now will accept the access and refresh tokens as attributes/config parameters, and uses them for subsequent API calls.

The class is unit-tested and should be ready to be merged for an end-to-end testing.